### PR TITLE
Added Support for RFLink RTS table and clearing RTS table Records

### DIFF
--- a/espRFLinkMQTT.h
+++ b/espRFLinkMQTT.h
@@ -156,6 +156,7 @@ static const char htmlMenu[] PROGMEM = ""     // Menu
 	"<a id='menuhome' class='menu' href='.'>&#8962;<span class='showmenulabel'>Home</span></a>\r\n"
 	"<a id='menuid' class='menu' href='/idfiltering'>&#10740;<span class='showmenulabel'>ID Filtering</span></a>\r\n"
 	"<a id='menulivedata' class='menu' href='/livedata'>&#128172;<span class='showmenulabel'>Live Data</span></a>\r\n"
+  "<a id='menurts' class='menu' href='/rts'>&#128272;<span class='showmenulabel'>RTS</span></a>\r\n"
 	"<a id='menusystem' class='menu' href='/system'>&#128295;<span class='showmenulabel'>System</span></a>\r\n"
 	"</div>\r\n"
 	"</header>\r\n"

--- a/espRFLinkMQTT.ino
+++ b/espRFLinkMQTT.ino
@@ -1238,8 +1238,10 @@ void ConfigHTTPserver() {
 		// Header + menu
 		htmlMessage += FPSTR(htmlMenu);
 		htmlMessage += "<script>\r\n";
-		if (!MQTTClient.connected()) {
-			htmlMessage += "window.onload = function() { document.getElementById('menunotification').innerHTML = 'Warning: MQTT not connected !';};\r\n"; };
+		if (!MQTTClient.connected()) 
+			htmlMessage += "window.onload = function() { document.getElementById('menunotification').innerHTML = 'Warning: MQTT not connected !'; rtsUpdate();};\r\n"; 
+    else
+			htmlMessage += "window.onload = function() { rtsUpdate();};\r\n";
 		htmlMessage += "document.getElementById('menurts').classList.add('active');</script>";
     htmlMessage += "<script>\r\n";
     htmlMessage += "function rtsCallback(data) {\r\n";

--- a/espRFLinkMQTT.ino
+++ b/espRFLinkMQTT.ino
@@ -1229,6 +1229,57 @@ void ConfigHTTPserver() {
 		//httpserver.send(303);
 	});
 	#endif
+
+  httpserver.on("/rts",[](){						// Url to restore ID filtering configuration from browser
+    String htmlMessage = "";
+		// Page start
+		htmlMessage += FPSTR(htmlStart);
+
+		// Header + menu
+		htmlMessage += FPSTR(htmlMenu);
+		htmlMessage += "<script>\r\n";
+		if (!MQTTClient.connected()) {
+			htmlMessage += "window.onload = function() { document.getElementById('menunotification').innerHTML = 'Warning: MQTT not connected !';};\r\n"; };
+		htmlMessage += "document.getElementById('menurts').classList.add('active');</script>";
+    htmlMessage += "<script>\r\n";
+    htmlMessage += "function rtsCallback(data) {\r\n";
+    htmlMessage += " document.getElementById('rtsshow').innerHTML = data;\r\n";
+    htmlMessage += "}\r\n";
+    htmlMessage += "function rtsUpdate() {\r\n";
+    htmlMessage += "  var xhttp = new XMLHttpRequest();\r\n";
+		htmlMessage += "  xhttp.onreadystatechange = function(){\r\n";
+		htmlMessage += "    if(this.readyState == 4 && this.status == 200){\r\n";
+		htmlMessage += "       alert(this);\r\n";
+		htmlMessage += "       rtsCallback(this.response);\r\n";
+		htmlMessage += "    }\r\n";
+		htmlMessage += "  };\r\n";
+		htmlMessage += "  xhttp.open(\"GET\", '/rts-show', true);\r\n";
+		htmlMessage += "  xhttp.send();\r\n";
+		htmlMessage += "}\r\n";
+    htmlMessage += "</script>";
+
+    // ;
+		htmlMessage += "<h3>RTS</h3>";
+    htmlMessage += "<input type='button' value='&#128260 Refresh' onclick='rtsUpdate();'>";
+    htmlMessage += "<table class='multirow multirow-left'><tr class='header'><th class='t-left'>Record</th><th class='t-left'>Address</th><th class='t-left'>RC</th></tr><tbody id='rtsshow'></tbody></table>";
+    
+
+    // Page end
+		htmlMessage += FPSTR(htmlEnd);
+
+		httpserver.send(200, "text/html", htmlMessage);
+	});
+
+httpserver.on("/rts-show",[](){						// Url to restore ID filtering configuration from browser
+    String htmlMessage = "";
+    htmlMessage += "<tr id='data0'><td>0</td><td>0x1263fbb3</td><td>12</td></tr>";
+    htmlMessage += "<tr id='data1'><td>1</td><td></td><td></td></tr>";
+    htmlMessage += "<tr id='data2'><td>2</td><td></td><td></td></tr>";
+    htmlMessage += "<tr id='data3'><td>3</td><td></td><td></td></tr>";
+    
+		httpserver.send(200, "text/html", htmlMessage);
+	});
+
  
   httpserver.onNotFound([](){
     httpserver.send(404, "text/plain", "404: Not found");      	// Send HTTP status 404 (Not Found) when there's no handler for the URI in the request

--- a/espRFLinkMQTT.ino
+++ b/espRFLinkMQTT.ino
@@ -1249,7 +1249,6 @@ void ConfigHTTPserver() {
     htmlMessage += "  var xhttp = new XMLHttpRequest();\r\n";
 		htmlMessage += "  xhttp.onreadystatechange = function(){\r\n";
 		htmlMessage += "    if(this.readyState == 4 && this.status == 200){\r\n";
-		// htmlMessage += "       alert(this);\r\n";
 		htmlMessage += "       rtsCallback(this.response);\r\n";
 		htmlMessage += "    }\r\n";
 		htmlMessage += "  };\r\n";
@@ -1270,7 +1269,7 @@ void ConfigHTTPserver() {
 		httpserver.send(200, "text/html", htmlMessage);
 	});
 
-httpserver.on("/rts-show",[](){						// Url to restore ID filtering configuration from browser
+httpserver.on("/rts-show",[](){	// URL to return RTS Show Data as a number of HTML Table Rows
     String htmlMessage = "";
     rflinkSerialTX.write("10;RTSSHOW;");
   	rflinkSerialTX.print(F("\r\n"));
@@ -1280,9 +1279,11 @@ httpserver.on("/rts-show",[](){						// Url to restore ID filtering configuratio
         delay(10);
         count--;
         if(count == 0) {
-          htmlMessage += "\r\nerror ";
-          htmlMessage += i;
-          httpserver.send(400, "text/plain", htmlMessage);
+          String err = "\r\nError Receiving RTSSHOW Response. We got to line ";
+          err += (i+1);
+          err += " of 16. Here is what we did receive:";
+          err += htmlMessage;
+          httpserver.send(500, "text/plain", err);
           return;
         }
       }
@@ -1296,7 +1297,6 @@ httpserver.on("/rts-show",[](){						// Url to restore ID filtering configuratio
 		httpserver.send(200, "text/html", htmlMessage);
 	});
 
- 
   httpserver.onNotFound([](){
     httpserver.send(404, "text/plain", "404: Not found");      	// Send HTTP status 404 (Not Found) when there's no handler for the URI in the request
   });

--- a/espRFLinkMQTT.ino
+++ b/espRFLinkMQTT.ino
@@ -1248,6 +1248,7 @@ void ConfigHTTPserver() {
     htmlMessage += " document.getElementById('rtsshow').innerHTML = data;\r\n";
     htmlMessage += "}\r\n";
     htmlMessage += "function rtsUpdate() {\r\n";
+    htmlMessage += "  document.getElementById('rtsshow').innerHTML = ''\r\n";
     htmlMessage += "  var xhttp = new XMLHttpRequest();\r\n";
 		htmlMessage += "  xhttp.onreadystatechange = function(){\r\n";
 		htmlMessage += "    if(this.readyState == 4 && this.status == 200){\r\n";
@@ -1257,12 +1258,15 @@ void ConfigHTTPserver() {
 		htmlMessage += "  xhttp.open(\"GET\", '/rts-show', true);\r\n";
 		htmlMessage += "  xhttp.send();\r\n";
 		htmlMessage += "}\r\n";
+    htmlMessage += "function rtsClear(line) {\r\n";
+    htmlMessage += "  alert('Clearing RTS Line '+line); \r\n";
+		htmlMessage += "}\r\n";
     htmlMessage += "</script>";
 
     // ;
 		htmlMessage += "<h3>RTS</h3>";
     htmlMessage += "<input type='button' value='&#128260 Refresh' onclick='rtsUpdate();'>";
-    htmlMessage += "<table class='multirow multirow-left'><tr class='header'><th class='t-left'>Record</th></tr><tbody id='rtsshow'></tbody></table>";
+    htmlMessage += "<table class='multirow' style='width:auto;'><tr class='header'><th>Record</th><th>RTS Code</th><th>Rolling Code</th><th></th></tr><tbody id='rtsshow'></tbody></table>";
     
 
     // Page end
@@ -1289,11 +1293,6 @@ httpserver.on("/rts-show",[](){	// URL to return RTS Show Data as a number of HT
           return;
         }
       }
-
-      htmlMessage += "<tr id='data";
-      htmlMessage += i;
-      htmlMessage += "'><td>";
-      htmlMessage += BUFFER;
 
       // Need to do some character buffer parsing here.. should not use Strings...
       // Process the line..."RTS Record: <rec_id> Address: <rts_code> RC: <rts_rc>\0"      
@@ -1333,12 +1332,19 @@ httpserver.on("/rts-show",[](){	// URL to return RTS Show Data as a number of HT
         curr++; // Next character
       }
       
+      htmlMessage += "<tr id='data";
+      htmlMessage += i;
+      htmlMessage += "'><td>";
       htmlMessage += String(line_nr);
-      htmlMessage += ",";
+      htmlMessage += "</td><td>";
       htmlMessage += String(rts_code);
-      htmlMessage += ",";
+      htmlMessage += "</td><td>";
       htmlMessage += String(rts_rc);
-      htmlMessage += "</td></tr>";
+      htmlMessage += "</td><td>";
+      htmlMessage += "<input type='button' value='clear' onclick='rtsClear(";
+      htmlMessage += i;
+      htmlMessage += ")'>";
+      htmlMessage += "</td></tr>";      
     }
 
     // Clear the buffer


### PR DESCRIPTION
I have added a page for RFLink RTS.

It shows the RFLink RTS Table (10;RTSSHOW) as well as giving you the ability to clear RTS Records (10;RTSRECCLEAR=<record>).

I also simplified the code to read from RFLINK and extracted it to a method (read_data_if_ready) so I could re use it when reading the multi line response from RTSSHOW.